### PR TITLE
:green_heart: Support debian 13 (trixie) again #19

### DIFF
--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -7,6 +7,7 @@ jobs:
       focal: ${{ steps.dockerhub.outputs.focal }}
       jammy: ${{ steps.dockerhub.outputs.jammy }}
       noble: ${{ steps.dockerhub.outputs.noble }}
+      trixie: ${{ steps.dockerhub.outputs.trixie }}
     runs-on: ubuntu-latest
     steps:
       - id: dockerhub
@@ -22,7 +23,7 @@ jobs:
               llvm) llvm[$codename]="$datetime,$digest";;
             esac
           done < <(
-            for dist in debian:bookworm debian:bullseye ubuntu:focal ubuntu:jammy ubuntu:noble; do
+            for dist in debian:bookworm debian:bullseye debian:trixie ubuntu:focal ubuntu:jammy ubuntu:noble; do
               distro=${dist%:*}
               codename=${dist#*:}
               version=$(
@@ -111,6 +112,13 @@ jobs:
     with:
       json: ${{ needs.dockerhub.outputs.noble }}
       name: noble
+  outdated_trixie:
+    needs:
+      - dockerhub
+    uses: ./.github/workflows/outdated.yml
+    with:
+      json: ${{ needs.dockerhub.outputs.trixie }}
+      name: trixie
   patch:
     if: ${{ needs.publish-if-outdated.outputs.outdated == 'true' }}
     name: Patch the description to DockerHub
@@ -130,8 +138,9 @@ jobs:
       - outdated_focal
       - outdated_jammy
       - outdated_noble
+      - outdated_trixie
     outputs:
-      outdated: ${{ steps.outdated.outputs.bookworm == 'true' || steps.outdated.outputs.bullseye == 'true' || steps.outdated.outputs.focal == 'true' || steps.outdated.outputs.jammy == 'true' || steps.outdated.outputs.noble == 'true' }}
+      outdated: ${{ steps.outdated.outputs.bookworm == 'true' || steps.outdated.outputs.bullseye == 'true' || steps.outdated.outputs.focal == 'true' || steps.outdated.outputs.jammy == 'true' || steps.outdated.outputs.noble == 'true' || steps.outdated.outputs.trixie == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - env:
@@ -210,6 +219,8 @@ jobs:
             distro: ubuntu
           - codename: noble
             distro: ubuntu
+          - codename: trixie
+            distro: debian
 name: Check updates
 on:
   schedule:

--- a/docker/linux/trixie/Dockerfile
+++ b/docker/linux/trixie/Dockerfile
@@ -18,12 +18,16 @@ RUN apt-fast update \
   && [ -d $keydir ] \
     || mkdir -pv $keydir \
   && gpg --export > $keydir/$keyname \
+  && distro=$(grep -E '^VERSION_CODENAME=.+$' < /etc/os-release) \
+  && distro=${distro#*=} \
   && for what in deb deb-src; do \
       printf \
-        '%s [signed-by=%s] http://%s/unstable/ llvm-toolchain main\n' \
+        '%s [signed-by=%s] http://%s/%s/ llvm-toolchain-%s main\n' \
           $what \
           $keydir/$keyname \
-          $llvm; \
+          $llvm \
+          $distro \
+          $distro; \
     done > /etc/apt/sources.list.d/llvm-toolchain.list \
   && apt-fast update \
   && apt-fast install --no-install-recommends --yes \


### PR DESCRIPTION
Fix URL for llvm-toolchain for debian 13 (trixie). It has been temporaliry disabled at the commit, 440a52e.