### PR TITLE
:green_heart: Don't fail on cache miss #24

### DIFF
--- a/.github/workflows/flang-runtime.yml
+++ b/.github/workflows/flang-runtime.yml
@@ -13,7 +13,6 @@ jobs:
         name: Restore the llvm source repository from cache
         uses: actions/cache/restore@v4
         with:
-          fail-on-cache-miss: true
           key: llvm-source-
           path: llvm-project
           restore-keys: llvm-source-*


### PR DESCRIPTION
'fail-on-cache-miss' should not be used for wildcard with 'restore-keys'