### PR TITLE
:green_heart: Add the repo restored from the cache as a safe directory

### DIFF
--- a/.github/workflows/flang-runtime.yml
+++ b/.github/workflows/flang-runtime.yml
@@ -66,6 +66,10 @@ jobs:
           key: llvm-source-
           path: llvm-project
           restore-keys: llvm-source-*
+      - name: Configure git
+        run: |
+          cd llvm-project
+          git config --global --add safe.directory $(pwd)
       - name: Reset to ${{ needs.clang.outputs.commit-hash }}
         run: |
           cd llvm-project


### PR DESCRIPTION
This suppresses the error, 'fatal: detected dubious ownership in repository'