### PR TITLE
:whale: Fix incorrect heredoc usage

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,4 +16,5 @@ trim_trailing_whitespace = false
 indent_style = tab
 
 [{Dockerfile,*.{json,yml}}]
+max_line_length = off
 tab_width = 2

--- a/.github/workflows/flang-runtime.yml
+++ b/.github/workflows/flang-runtime.yml
@@ -12,14 +12,14 @@ jobs:
       - name: Download the keyring for github cli
         run: |
           aria2c -d /etc/apt/keyrings https://cli.github.com/packages/githubcli-archive-keyring.gpg
-          cat << _EOT_
+          cat << _EOT_ > /etc/apt/sources.list.d/github-cli.sources
           Enabled: yes
           Types: deb
           URIs: https://cli.github.com/packages/
           Suites: stable
           Components: main
           Signed-By: /etc/apt/keyrings/githubcli-archive-keyring.gpg
-          _EOT_ > /etc/apt/sources.list.d/github-cli.sources
+          _EOT_
       - env:
           DEBCONF_NOWARNINGS: yes
           DEBIAN_FRONTEND: noninteractive


### PR DESCRIPTION
I hope that this change solves the first problem, `1. Installation of the GitHub CLI (gh) fails.`, at the issue #68.
