### PR TITLE
:green_heart: Skip building the flang runtime if it already exists

### DIFF
--- a/.github/workflows/flang-runtime.yml
+++ b/.github/workflows/flang-runtime.yml
@@ -1,10 +1,11 @@
 jobs:
   build:
     container: ${{ needs.clang.outputs.container }}
-    if: ${{ needs.clang.outputs.outdated == 'true' }}
+    if: ${{ needs.clang.outputs.outdated == 'true' && needs.flang_runtime.outputs.path != 'null' }}
     name: Build flang runtime
     needs:
       - clang
+      - flang_runtime
     outputs:
       major-version: ${{ steps.major.outputs.version }}
     runs-on: ubuntu-latest
@@ -126,12 +127,31 @@ jobs:
     with:
       DOCKERHUB_USERNAME: ${{ inputs.DOCKERHUB_USERNAME }}
       codename: ${{ inputs.codename }}
-  install:
+  flang_runtime:
+    container: ${{ needs.clang.outputs.container }}
     if: ${{ needs.clang.outputs.outdated == 'true' }}
+    name: Check the necessity to build libflang_runtime.a
+    needs:
+      - clang
+    outputs:
+      path: ${{ steps.file.outputs.path }}
+    runs-on: ubuntu-latest
+    steps:
+      - id: file
+        name: Does the file exist
+        run: |
+          echo path=$(
+            find / -name '*flang_rt*' \
+              | head -n1 \
+            || echo null
+          ) | tee -a $GITHUB_OUTPUT
+  install:
+    if: ${{ needs.clang.outputs.outdated == 'true' && needs.flang_runtime.outputs.path != 'null' }}
     name: Install flang runtime
     needs:
       - build
       - clang
+      - flang_runtime
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -172,6 +192,26 @@ jobs:
           push: true
           tags: |
             ${{ steps.tags.outputs.tags }}
+  skip_building:
+    if: ${{ needs.clang.outputs.outdated == 'true' && needs.flang_runtime.outputs.path == 'null' }}
+    name: Push only tags without building the flang runtime
+    needs:
+      - clang
+      - flang_runtime
+    runs-on: ubuntu-latest
+    steps:
+      - name: Push tags
+        run: |
+          clang=${{ vars.DOCKERHUB_USERNAME }}/clang:${{ needs.clang.outputs.distro-name }}-latest
+          docker pull $clang
+          llvm=${{ vars.DOCKERHUB_USERNAME }}/llvm:${{ inputs.codename }}
+          docker tag $clang $llvm
+          docker push $llvm
+          for suffix in latest ${{ needs.clang.outputs.datetime }}; do
+            llvm=${{ vars.DOCKERHUB_USERNAME }}/llvm:${{ needs.clang.outputs.distro-name }}-$suffix
+            docker tag $clang $llvm
+            docker push $llvm
+          done
 name: flang runtime
 on:
   workflow_call:


### PR DESCRIPTION
According to the issue #70, the flang runtime is now available in upstream packages, so unnecessary builds are skipped when it is already present. However, since there is no guarantee that upstream packages will always include it, the fallback path to build it locally is retained.