### PR TITLE
:whale: Replace apt-fast base images with upstream distro images

### DIFF
--- a/.github/workflows/flang-runtime.yml
+++ b/.github/workflows/flang-runtime.yml
@@ -12,7 +12,8 @@ jobs:
     steps:
       - name: Download the keyring for github cli
         run: |
-          aria2c -d /etc/apt/keyrings https://cli.github.com/packages/githubcli-archive-keyring.gpg
+          curl https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+            > /etc/apt/keyrings/githubcli-archive-keyring.gpg
           cat << _EOT_ > /etc/apt/sources.list.d/github-cli.sources
           Enabled: yes
           Types: deb
@@ -26,8 +27,8 @@ jobs:
           DEBIAN_FRONTEND: noninteractive
         name: Install `apt` packages
         run: |
-          apt-fast update
-          apt-fast install \
+          apt update
+          apt install \
               --no-install-recommends \
               --yes \
             gh \

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 [`docker-llvm`][github-repo-url] - Debian/Ubuntu with the latest [llvm][llvm-url] installed.
 
-This image depends on [![`snowstep/apt-fast`][dockerhub-apt-fast-image]][dockerhub-apt-fast-url]
-
 ## Naming Conventions
 
 - `snowstep/clang`: Without flang runtime
@@ -27,8 +25,6 @@ For each `<distro>-<version>` combination, the latest image is assigned two addi
 
 [docker-image]:https://img.shields.io/docker/v/snowstep/llvm?logo=docker
 [docker-url]:https://hub.docker.com/r/snowstep/llvm
-[dockerhub-apt-fast-image]:https://img.shields.io/docker/v/snowstep/apt-fast?label=snowstep%2Fapt-fast&logo=docker
-[dockerhub-apt-fast-url]:https://hub.docker.com/r/snowstep/apt-fast
 [github-repo-image]:https://img.shields.io/badge/github-kei--g%2Fdocker--llvm-brightgreen?logo=github
 [github-repo-url]:https://github.com/kei-g/docker-llvm
 [license-image]:https://img.shields.io/github/license/kei-g/docker-llvm

--- a/docker/linux/bookworm/Dockerfile
+++ b/docker/linux/bookworm/Dockerfile
@@ -1,19 +1,23 @@
 # Install the latest LLVM
-FROM snowstep/apt-fast:bookworm
+FROM debian:bookworm
 
 ARG MAJOR_VERSION
 ENV MAJOR_VERSION=${MAJOR_VERSION:-23}
 
 RUN DEBCONF_NOWARNINGS=yes \
   && DEBIAN_FRONTEND=noninteractive \
-  && apt-fast update \
-  && apt-fast upgrade --yes \
-  && apt-fast install --no-install-recommends --yes \
+  && apt update \
+  && apt upgrade --yes \
+  && apt install --no-install-recommends --yes \
+    ca-certificates \
+    curl \
     gnupg \
+    sudo \
+    tzdata \
   && keyname=llvm-snapshot.gpg \
   && keydir=/etc/apt/keyrings \
   && llvm=apt.llvm.org \
-  && aria2c https://$llvm/$keyname.key \
+  && curl https://$llvm/$keyname.key > $keyname.key \
   && gpg --import $keyname.key \
   && rm -f $keyname.key \
   && [ -d $keydir ] \
@@ -29,8 +33,8 @@ RUN DEBCONF_NOWARNINGS=yes \
           $codename \
           $codename; \
     done > /etc/apt/sources.list.d/llvm-toolchain.list \
-  && apt-fast update \
-  && apt-fast install --no-install-recommends --yes \
+  && apt update \
+  && apt install --no-install-recommends --yes \
     clang-${MAJOR_VERSION} \
     clang-format-${MAJOR_VERSION} \
     clang-tidy-${MAJOR_VERSION} \

--- a/docker/linux/bullseye/Dockerfile
+++ b/docker/linux/bullseye/Dockerfile
@@ -1,19 +1,23 @@
 # Install the latest LLVM
-FROM snowstep/apt-fast:bullseye
+FROM debian:bullseye
 
 ARG MAJOR_VERSION
 ENV MAJOR_VERSION=${MAJOR_VERSION:-23}
 
 RUN DEBCONF_NOWARNINGS=yes \
   && DEBIAN_FRONTEND=noninteractive \
-  && apt-fast update \
-  && apt-fast upgrade --yes \
-  && apt-fast install --no-install-recommends --yes \
+  && apt update \
+  && apt upgrade --yes \
+  && apt install --no-install-recommends --yes \
+    ca-certificates \
+    curl \
     gnupg \
+    sudo \
+    tzdata \
   && keyname=llvm-snapshot.gpg \
   && keydir=/etc/apt/keyrings \
   && llvm=apt.llvm.org \
-  && aria2c https://$llvm/$keyname.key \
+  && curl https://$llvm/$keyname.key > $keyname.key \
   && gpg --import $keyname.key \
   && rm -f $keyname.key \
   && [ -d $keydir ] \
@@ -29,8 +33,8 @@ RUN DEBCONF_NOWARNINGS=yes \
           $codename \
           $codename; \
     done > /etc/apt/sources.list.d/llvm-toolchain.list \
-  && apt-fast update \
-  && apt-fast install --no-install-recommends --yes \
+  && apt update \
+  && apt install --no-install-recommends --yes \
     clang-${MAJOR_VERSION} \
     clang-format-${MAJOR_VERSION} \
     clang-tidy-${MAJOR_VERSION} \

--- a/docker/linux/focal/Dockerfile
+++ b/docker/linux/focal/Dockerfile
@@ -1,19 +1,23 @@
 # Install the latest LLVM
-FROM snowstep/apt-fast:focal
+FROM ubuntu:focal
 
 ARG MAJOR_VERSION
 ENV MAJOR_VERSION=${MAJOR_VERSION:-23}
 
 RUN DEBCONF_NOWARNINGS=yes \
   && DEBIAN_FRONTEND=noninteractive \
-  && apt-fast update \
-  && apt-fast upgrade --yes \
-  && apt-fast install --no-install-recommends --yes \
+  && apt update \
+  && apt upgrade --yes \
+  && apt install --no-install-recommends --yes \
+    ca-certificates \
+    curl \
     gnupg \
+    sudo \
+    tzdata \
   && keyname=llvm-snapshot.gpg \
   && keydir=/etc/apt/keyrings \
   && llvm=apt.llvm.org \
-  && aria2c https://$llvm/$keyname.key \
+  && curl https://$llvm/$keyname.key > $keyname.key \
   && gpg --import $keyname.key \
   && rm -f $keyname.key \
   && [ -d $keydir ] \
@@ -29,9 +33,9 @@ RUN DEBCONF_NOWARNINGS=yes \
           $codename \
           $codename; \
     done > /etc/apt/sources.list.d/llvm-toolchain.list \
-  && apt-fast update \
-  && apt-fast upgrade --yes \
-  && apt-fast install --no-install-recommends --yes \
+  && apt update \
+  && apt upgrade --yes \
+  && apt install --no-install-recommends --yes \
     clang-${MAJOR_VERSION} \
     clang-format-${MAJOR_VERSION} \
     clang-tidy-${MAJOR_VERSION} \
@@ -40,7 +44,7 @@ RUN DEBCONF_NOWARNINGS=yes \
     libunwind-${MAJOR_VERSION}-dev \
     lld-${MAJOR_VERSION} \
     lldb-${MAJOR_VERSION} \
-  && apt-fast install --no-install-recommends --yes \
+  && apt install --no-install-recommends --yes \
     libc++-${MAJOR_VERSION}-dev \
     libc++abi-${MAJOR_VERSION}-dev \
     libclang-${MAJOR_VERSION}-dev \

--- a/docker/linux/jammy/Dockerfile
+++ b/docker/linux/jammy/Dockerfile
@@ -1,19 +1,23 @@
 # Install the latest LLVM
-FROM snowstep/apt-fast:jammy
+FROM ubuntu:jammy
 
 ARG MAJOR_VERSION
 ENV MAJOR_VERSION=${MAJOR_VERSION:-23}
 
 RUN DEBCONF_NOWARNINGS=yes \
   && DEBIAN_FRONTEND=noninteractive \
-  && apt-fast update \
-  && apt-fast upgrade --yes \
-  && apt-fast install --no-install-recommends --yes \
+  && apt update \
+  && apt upgrade --yes \
+  && apt install --no-install-recommends --yes \
+    ca-certificates \
+    curl \
     gnupg \
+    sudo \
+    tzdata \
   && keyname=llvm-snapshot.gpg \
   && keydir=/etc/apt/keyrings \
   && llvm=apt.llvm.org \
-  && aria2c https://$llvm/$keyname.key \
+  && curl https://$llvm/$keyname.key > $keyname.key \
   && gpg --import $keyname.key \
   && rm -f $keyname.key \
   && [ -d $keydir ] \
@@ -29,9 +33,9 @@ RUN DEBCONF_NOWARNINGS=yes \
           $codename \
           $codename; \
     done > /etc/apt/sources.list.d/llvm-toolchain.list \
-  && apt-fast update \
-  && apt-fast upgrade --yes \
-  && apt-fast install --no-install-recommends --yes \
+  && apt update \
+  && apt upgrade --yes \
+  && apt install --no-install-recommends --yes \
     clang-${MAJOR_VERSION} \
     clang-format-${MAJOR_VERSION} \
     clang-tidy-${MAJOR_VERSION} \
@@ -40,7 +44,7 @@ RUN DEBCONF_NOWARNINGS=yes \
     libunwind-${MAJOR_VERSION}-dev \
     lld-${MAJOR_VERSION} \
     lldb-${MAJOR_VERSION} \
-  && apt-fast install --no-install-recommends --yes \
+  && apt install --no-install-recommends --yes \
     libc++-${MAJOR_VERSION}-dev \
     libc++abi-${MAJOR_VERSION}-dev \
     libclang-${MAJOR_VERSION}-dev \

--- a/docker/linux/noble/Dockerfile
+++ b/docker/linux/noble/Dockerfile
@@ -1,19 +1,23 @@
 # Install the latest LLVM
-FROM snowstep/apt-fast:noble
+FROM ubuntu:noble
 
 ARG MAJOR_VERSION
 ENV MAJOR_VERSION=${MAJOR_VERSION:-23}
 
 RUN DEBCONF_NOWARNINGS=yes \
   && DEBIAN_FRONTEND=noninteractive \
-  && apt-fast update \
-  && apt-fast upgrade --yes \
-  && apt-fast install --no-install-recommends --yes \
+  && apt update \
+  && apt upgrade --yes \
+  && apt install --no-install-recommends --yes \
+    ca-certificates \
+    curl \
     gnupg \
+    sudo \
+    tzdata \
   && keyname=llvm-snapshot.gpg \
   && keydir=/etc/apt/keyrings \
   && llvm=apt.llvm.org \
-  && aria2c https://$llvm/$keyname.key \
+  && curl https://$llvm/$keyname.key > $keyname.key \
   && gpg --import $keyname.key \
   && rm -f $keyname.key \
   && [ -d $keydir ] \
@@ -29,9 +33,9 @@ RUN DEBCONF_NOWARNINGS=yes \
           $codename \
           $codename; \
     done > /etc/apt/sources.list.d/llvm-toolchain.list \
-  && apt-fast update \
-  && apt-fast upgrade --yes \
-  && apt-fast install --no-install-recommends --yes \
+  && apt update \
+  && apt upgrade --yes \
+  && apt install --no-install-recommends --yes \
     clang-${MAJOR_VERSION} \
     clang-format-${MAJOR_VERSION} \
     clang-tidy-${MAJOR_VERSION} \
@@ -40,7 +44,7 @@ RUN DEBCONF_NOWARNINGS=yes \
     libunwind-${MAJOR_VERSION}-dev \
     lld-${MAJOR_VERSION} \
     lldb-${MAJOR_VERSION} \
-  && apt-fast install --no-install-recommends --yes \
+  && apt install --no-install-recommends --yes \
     libc++-${MAJOR_VERSION}-dev \
     libc++abi-${MAJOR_VERSION}-dev \
     libclang-${MAJOR_VERSION}-dev \

--- a/docker/linux/trixie/Dockerfile
+++ b/docker/linux/trixie/Dockerfile
@@ -1,19 +1,23 @@
 # Install the latest LLVM
-FROM snowstep/apt-fast:trixie
+FROM debian:trixie
 
 ARG MAJOR_VERSION
 ENV MAJOR_VERSION=${MAJOR_VERSION:-23}
 
 RUN DEBCONF_NOWARNINGS=yes \
   && DEBIAN_FRONTEND=noninteractive \
-  && apt-fast update \
-  && apt-fast upgrade --yes \
-  && apt-fast install --no-install-recommends --yes \
+  && apt update \
+  && apt upgrade --yes \
+  && apt install --no-install-recommends --yes \
+    ca-certificates \
+    curl \
     gnupg \
+    sudo \
+    tzdata \
   && keyname=llvm-snapshot.gpg \
   && keydir=/etc/apt/keyrings \
   && llvm=apt.llvm.org \
-  && aria2c https://$llvm/$keyname.key \
+  && curl https://$llvm/$keyname.key > $keyname.key \
   && gpg --import $keyname.key \
   && rm -f $keyname.key \
   && [ -d $keydir ] \
@@ -29,8 +33,8 @@ RUN DEBCONF_NOWARNINGS=yes \
           $codename \
           $codename; \
     done > /etc/apt/sources.list.d/llvm-toolchain.list \
-  && apt-fast update \
-  && apt-fast install --no-install-recommends --yes \
+  && apt update \
+  && apt install --no-install-recommends --yes \
     clang-${MAJOR_VERSION} \
     clang-format-${MAJOR_VERSION} \
     clang-tidy-${MAJOR_VERSION} \


### PR DESCRIPTION
Use the standard `apt` workflow instead of `apt-fast` and replace `aria2c` usage with `curl`.

For compatibility with the previous base images, explicitly install some packages that were previously provided implicitly. These compatibility adjustments are expected to be cleaned up in later changes.

This removes the dependency on `snowstep/apt-fast` and simplifies the image build process.

See #75 for the discussion and rationale behind this change.