### PR TITLE
Update Dockerfile to copy the files for Fortran's modules

### DIFF
--- a/docker/build-flang-runtime/Dockerfile
+++ b/docker/build-flang-runtime/Dockerfile
@@ -1,4 +1,4 @@
 FROM snowstep/clang:__BASE__
 
-COPY finclude /usr/lib/clang/23/
+COPY bin /usr/lib/clang/23/
 COPY lib /usr/lib/clang/23/


### PR DESCRIPTION
This is necessary also for #78