### PR TITLE
:bug: Correct paths to install Fortran's modules

### DIFF
--- a/docker/build-flang-runtime/Dockerfile
+++ b/docker/build-flang-runtime/Dockerfile
@@ -1,4 +1,4 @@
 FROM snowstep/clang:__BASE__
 
-COPY bin /usr/lib/clang/23/
-COPY lib /usr/lib/clang/23/
+COPY bin/ /usr/lib/llvm-23/lib/clang/23/bin
+COPY lib/ /usr/lib/llvm-23/lib/clang/23/lib


### PR DESCRIPTION
Installation paths must be `/usr/lib/llvm-${major_version}/lib/clang/${major_version}/{bin,lib}`