### PR TITLE
:green_heart: Test the intrinsic modules on another job

### DIFF
--- a/.github/workflows/flang-runtime.yml
+++ b/.github/workflows/flang-runtime.yml
@@ -109,9 +109,6 @@ jobs:
         run: |
           cd build
           ninja install
-      - name: Test
-        run: |
-          flang examples/flang/hello-mods.F90
       - id: major
         name: Get major version
         run: |
@@ -139,6 +136,8 @@ jobs:
     needs:
       - build
       - clang
+    outputs:
+      digest: ${{ steps.published.outputs.digest }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -170,7 +169,8 @@ jobs:
             type=raw,value=${{ inputs.codename }}
             type=raw,value=${{ needs.clang.outputs.distro-name }}-latest
             type=raw,value=${{ needs.clang.outputs.distro-name }}-${{ needs.clang.outputs.datetime }}
-      - name: Run Buildx and Push it to DockerHub
+      - id: published
+        name: Run Buildx and Push it to DockerHub
         uses: docker/build-push-action@v7
         with:
           build-args: |
@@ -179,6 +179,22 @@ jobs:
           push: true
           tags: |
             ${{ steps.tags.outputs.tags }}
+  test:
+    if: ${{ needs.clang.outputs.outdated == 'true' }}
+    container: ${{ needs.install.outputs.digest }}
+    name: Test
+    needs:
+      - install
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+      - name: Intrinsic Module
+        run: |
+          flang examples/flang/hello-mods.F90
+          ./a.out
 name: flang runtime
 on:
   workflow_call:


### PR DESCRIPTION
Because Fortran's modules are built and are installed to '/dist' at the job, 'build', we can not use them by that job.

See also #78
