### PR TITLE
:green_heart: Parameterize the LLVM major version in the Dockerfile

### DIFF
--- a/.github/workflows/flang-runtime.yml
+++ b/.github/workflows/flang-runtime.yml
@@ -150,7 +150,7 @@ jobs:
           name: libflang_rt-${{ inputs.codename }}-${{ needs.clang.outputs.datetime }}-${{ needs.clang.outputs.commit-hash }}
       - name: Copy Dockerfile
         run: |
-          sed -r 's/__BASE__/${{ needs.clang.outputs.distro-name }}-${{ needs.clang.outputs.datetime }}/g' \
+          sed -r 's/__BASE__/${{ needs.clang.outputs.distro-name }}-${{ needs.clang.outputs.datetime }}/g; s/__MAJOR_VERSION__/${{ needs.build.outputs.major-version }}/g' \
             < docker/build-flang-runtime/Dockerfile \
             > Dockerfile
       - name: Setup Docker Buildx

--- a/docker/build-flang-runtime/Dockerfile
+++ b/docker/build-flang-runtime/Dockerfile
@@ -1,9 +1,9 @@
 FROM snowstep/clang:__BASE__
 
-RUN cd /usr/lib/llvm-23/lib/clang/23 \
+RUN cd /usr/lib/llvm-__MAJOR_VERSION__/lib/clang/__MAJOR_VERSION__ \
   && mkdir finclude lib/x86_64-unknown-linux-gnu
 
-COPY bin/ /usr/lib/llvm-23/bin/
-COPY lib/ /usr/lib/llvm-23/lib/
+COPY bin/ /usr/lib/llvm-__MAJOR_VERSION__/bin/
+COPY lib/ /usr/lib/llvm-__MAJOR_VERSION__/lib/
 
-RUN chmod 755 /usr/lib/llvm-23/bin/flang-23
+RUN chmod 755 /usr/lib/llvm-__MAJOR_VERSION__/bin/flang-__MAJOR_VERSION__


### PR DESCRIPTION
Replace hard-coded LLVM major version numbers with the `__MAJOR_VERSION__` placeholder and substitute it during the workflow.

This allows the Dockerfile to adapt automatically when apt.llvm.org advances to a new LLVM major version.

See also #88